### PR TITLE
Fix compilation issues with Clang on Mac

### DIFF
--- a/false-sharing/false-sharing.cpp
+++ b/false-sharing/false-sharing.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
     }
     assert(((uintptr_t)memory & 0x3F) == 0);
 #else
-    memory = malloc(totalSize);
+    memory = static_cast<size_t*>(malloc(totalSize));
 #endif
 
     using Clock = std::chrono::system_clock;

--- a/prefetching/prefetching.cpp
+++ b/prefetching/prefetching.cpp
@@ -6,6 +6,11 @@
 #include <algorithm>
 #include <cstring>
 
+#if defined(__clang__) && defined(__APPLE__)
+#include <xmmintrin.h>
+using _mm_hint = uint8_t;
+#endif
+
 #define REPETITIONS 5
 #define SIZE 10 * 1024 * 1024
 


### PR DESCRIPTION
A few issues compiling with AppleClang 10.0.0.10001044 on Mojave:

A bunch of prefetch intrinsic issues:
```
error: unknown type name '_mm_hint'
error: use of undeclared identifier '_MM_HINT_T0'
...
```

and

```
error: assigning to 'size_t *' (aka 'unsigned long *') from incompatible type 'void *'
```