### PR TITLE
use SSE movnti for streaming stores

### DIFF
--- a/write-combining/write-combining.cpp
+++ b/write-combining/write-combining.cpp
@@ -1,10 +1,11 @@
 #include <iostream>
+#include <iomanip>
 #include <chrono>
 #include <thread>
 #include <cassert>
 #include <vector>
 #include <cstring>
-#include <xmmintrin.h>
+#include <immintrin.h>
 
 #define ARRAY_SIZE 2 * 1024 * 1024
 #define REPEAT 20
@@ -57,13 +58,13 @@ int main(int argc, char** argv)
                 for (int i = region.first; i < region.second; i++)
                 {
                     // non-temporal store, bypasses cache
-                    _mm_stream_pi((__m64*) &arrays[i][l], reinterpret_cast<__m64>(static_cast<Type>(l)));
+                    _mm_stream_si64(reinterpret_cast<long long *>(&arrays[i][l]), static_cast<Type>(l));
                 }
             }
         }
     }
 
-    std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count() << std::endl;
+    std::cerr << std::setw(5) << std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count() << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
Uses 64-bit `movnti` rather than ` _mm_stream_pi` which is an older MMX instruction which are less well supported by the newest CPUs. Compiles to better code since the compiler doesn't need to shuffle the value into an MMX register.

The main impact is that small increments aren't as penalized anymore. Before, I got:

```
$ for i in {1..20}; do printf "%2d " $i ; ./write-combining 20 $i; done
 1 3693
 2 1920
 3 1381
 4 1043
 5 950
 6 1017
 7 892
 8 906
 9 2008
10 2271
```

Note that for increment 1 especially it is very slow, about 4x or 5x slower than ideal, because the scheduler gets clogged up with instructions and MLP is reduced. After, it looks like:

```
 1  1412
 2  1327
 3  1025
 4   939
 5   907
 6   931
 7   880
 8   883
 9  1955
10  2039
```

The first few increments are still slower the later ones, but by a smaller factor and overall the result more reflects the hardware. To get rid of all the performance degradation you would have to change how the loops are written, e.g., use a dedicated function for each increment value.