### PR TITLE
Refactored for more simplicity and readability

### DIFF
--- a/misaligned-access/misaligned-access.cpp
+++ b/misaligned-access/misaligned-access.cpp
@@ -42,12 +42,12 @@ int main(int argc, char** argv)
 
     Type* memory;
 
-    // allocated two cache lines worth of Type
-    size_t size = sizeof(Type) * (CACHE_LINE_SIZE / sizeof(Type)) * 2;
+    // allocated two cache lines
+    size_t size = CACHE_LINE_SIZE * 2;
 #ifdef _MSC_VER
-    memory = _aligned_malloc(size, 64);
+    memory = _aligned_malloc(size, CACHE_LINE_SIZE);
 #else
-    if (posix_memalign((void**) &memory, 64, size))
+    if (posix_memalign((void**) &memory, CACHE_LINE_SIZE, size))
     {
         std::cerr << "Couldn't allocate memory" << std::endl;
         return 1;


### PR DESCRIPTION
Replace 64 with CACHE_LINE_SIZE directive
More explicitly convey allocated array (memory) is 2 cache lines in size