### PR TITLE
Update misaligned-access.cpp

### DIFF
--- a/misaligned-access/misaligned-access.cpp
+++ b/misaligned-access/misaligned-access.cpp
@@ -3,30 +3,28 @@
 #include <vector>
 #include <cstdint>
 #include <cassert>
+#include <xmmintrin.h>
 
 #define CACHE_LINE_SIZE 64
 
 #ifndef REPETITIONS
-    #define REPETITIONS 100 * 1024 * 1024
+#define REPETITIONS 100 * 1024 * 1024
 #endif
 
-using Type = uint32_t;
+using Type = double;
 
 void test_memory(std::vector<Type*>& memory)
 {
     using Clock = std::chrono::steady_clock;
-
     size_t size = memory.size();
+
     auto start = Clock::now();
 
     for (int i = 0; i < REPETITIONS; i++)
     {
-        for (size_t j = 0; j < size; j++)
-        {
-            *memory[j] += j;
-        }
+        _mm_stream_pi((__m64*)(memory[0]), reinterpret_cast<__m64>(0));
+        //*memory[j] += j;
     }
-
     std::cerr << std::chrono::duration_cast<std::chrono::milliseconds>(Clock::now() - start).count() << std::endl;
 }
 


### PR DESCRIPTION
remove the cache effect (I try several times, not as obvious as directly write to memory). So that the misaligned access effect can be seen. (Correct me if I am wrong)

On Sandy Bridge:

```
Offset: 0, Time: 73.0
Offset: 1, Time: 76.0
Offset: 60, Time: 109.0
Offset: 61, Time: 108.4
Offset: 62, Time: 107.6
Offset: 63, Time: 109.2
Offset: 64, Time: 72.4
```

On SkyLake:
```
Offset: 0, Time: 40.0
Offset: 1, Time: 40.0
Offset: 60, Time: 61.0
Offset: 61, Time: 61.0
Offset: 62, Time: 61.0
Offset: 63, Time: 61.0
Offset: 64, Time: 40.0
```
